### PR TITLE
Make Jest ignore Cypress tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,8 @@ const customJestConfig = {
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testEnvironment: 'jest-environment-jsdom',
+  // Ignore Cypress tests in unit testing
+  modulePathIgnorePatterns: ['./cypress'],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async


### PR DESCRIPTION
Related: #21 
https://github.com/codeforjapan/hackdays/issues/21#issuecomment-1042554221

To avoid the E2E tests to be run in unit testing